### PR TITLE
Extend FragmentActivity

### DIFF
--- a/Viewpager_circle_indicator/app/src/main/java/javaant/com/viewpager_circle_indicator/MainActivity.java
+++ b/Viewpager_circle_indicator/app/src/main/java/javaant/com/viewpager_circle_indicator/MainActivity.java
@@ -5,7 +5,7 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 
-public class MainActivity extends Activity {
+public class MainActivity extends FragmentActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
Extending to an Activity class makes the app crashes, it should extend FragmentActivity instead.
